### PR TITLE
Upgrade node-ignore -> 3.x to solve several problems

### DIFF
--- a/lib/build/font_compress/spider/utils.js
+++ b/lib/build/font_compress/spider/utils.js
@@ -215,7 +215,7 @@ function isRemoteFile (src) {
  * @param   {String}    路径
  */
 function dirname (src) {
-    
+
     if (isRemoteFile(src)) {
 
         // http://www.font-spider.org/////
@@ -287,9 +287,7 @@ function ignoreFactory (ignoreList) {
         return ignoreList;
     }
 
-    var fn = ignore({
-        ignore: ignoreList || []
-    });
+    var fn = ignore().add(ignoreList || []);
 
     // @param   {String}
     // @return  {Boolean}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-postcss": "^6.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "ignore": "^2.2.15",
+    "ignore": "^3.0.9",
     "inquirer": "^0.11.0",
     "js-beautify": "^1.5.10",
     "jsftp": "^1.5.3",


### PR DESCRIPTION
Upgrades [`node-ignore`](https://www.npmjs.com/package/ignore) to the latest `3.0.9` to solve several known issues, including:

- Files should not be re-included if the parent directory is ignored.
- Works for [windows](https://ci.appveyor.com/project/kaelzhang/node-ignore), finally.
- Better Handling with trailing whitespaces, wildcards of ignore patterns, according to [gitignore spec](https://git-scm.com/docs/gitignore), and passed all cases described in the spec.