### PR TITLE
https://gems.ruby-china.org 地址失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ $ [sudo] gem install compass
 由于墙的缘故（你懂的），原始的gem源[https://rubygems.org/](https://rubygems.org/) 几乎无法使用，建议将gem源替换成 [ruby-china](http://gems.ruby-china.org) 的源
 
 ```
-$ gem sources --add https://gems.ruby-china.org/ --remove https://rubygems.org/
+$ gem sources --add https://gems.ruby-china.com/ --remove https://rubygems.org/
 $ gem sources -l
 *** CURRENT SOURCES ***
 
-https://gems.ruby-china.org
-# 请确保只有 gems.ruby-china.org
+https://gems.ruby-china.com
+# 请确保只有 gems.ruby-china.com
 $ gem install compass
 ```
 


### PR DESCRIPTION
服务域名更换公告
因域名备案问题，.org 域名无法继续提供 RubyGems 镜像服务，我们提供 .com 代替 .org 的域名，其他一切不变！！

详情访问

https://gems.ruby-china.com